### PR TITLE
Implement automatic redirect creation for moved pages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ local_settings.py
 .DS_Store
 .cache/
 .pytest_cache/
+env/

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 from os import path
 
-install_requires = ["wagtail"]
+install_requires = ["wagtail<2.11"]
 
 tests_require = ["pytest-django", "wagtail-factories", "pytest"]
 

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 from os import path
 
-install_requires = ["wagtail<2.11"]
+install_requires = ["wagtail"]
 
 tests_require = ["pytest-django", "wagtail-factories", "pytest"]
 

--- a/tests/test_pages.py
+++ b/tests/test_pages.py
@@ -95,3 +95,55 @@ def test_index_page_slug_change_create_redirects_child_pages(client, site):
 
     response = client.get('/index-page/test-page-2/')
     assert response.status_code == 301
+
+
+@pytest.mark.django_db
+def test_move_page_from_one_index_to_another_creates_redirect(client, site):
+    test_index_page_1 = factories.AutomaticRedirectsTestIndexPageFactory(
+        parent=site.root_page,
+        title='Automatic redirects test index page 1',
+        slug='index-page-1',
+        subtitle='Test subtitle',
+        body='<p>Test body</p>',
+    )
+
+    response = client.get(test_index_page_1.get_url())
+    assert response.status_code == 200
+
+    test_index_page_2 = factories.AutomaticRedirectsTestIndexPageFactory(
+        parent=site.root_page,
+        title='Automatic redirects test index page 2',
+        slug='index-page-2',
+        subtitle='Test subtitle',
+        body='<p>Test body</p>',
+    )
+
+    response = client.get(test_index_page_2.get_url())
+    assert response.status_code == 200
+    assert 'index-page-2' in test_index_page_2.get_url()
+
+    test_page = factories.AutomaticRedirectsTestPageFactory(
+        parent=test_index_page_1,
+        title='Test Page',
+        slug='test-page'
+    )
+
+    test_page_url_pre_move = test_page.get_url()
+    response = client.get(test_page_url_pre_move)
+    assert response.status_code == 200
+    assert test_index_page_1.get_url() in test_page_url_pre_move
+
+    test_page.move(test_index_page_2, 'last-child')
+    test_page.refresh_from_db()
+
+    test_page_url_post_move = test_page.get_url()
+    assert test_index_page_1.get_descendants().count() == 0
+    assert test_index_page_2.get_descendants().count() == 1
+    assert test_index_page_1.get_url() not in test_page_url_post_move
+    assert test_index_page_2.get_url() in test_page_url_post_move
+
+    response = client.get(test_page_url_post_move)
+    assert response.status_code == 200
+    response = client.get(test_page_url_pre_move)
+    assert response.status_code == 301
+

--- a/tests/test_pages.py
+++ b/tests/test_pages.py
@@ -1,5 +1,7 @@
 import pytest
 
+from wagtail import VERSION as WAGTAIL_VERSION
+
 from tests.testapp import factories
 
 
@@ -97,6 +99,10 @@ def test_index_page_slug_change_create_redirects_child_pages(client, site):
     assert response.status_code == 301
 
 
+@pytest.mark.skipif(
+    WAGTAIL_VERSION < (2, 10),
+    reason="Move signals require wagtail 2.10 or higher"
+)
 @pytest.mark.django_db
 def test_move_page_from_one_index_to_another_creates_redirect(client, site):
     test_index_page_1 = factories.AutomaticRedirectsTestIndexPageFactory(
@@ -148,8 +154,10 @@ def test_move_page_from_one_index_to_another_creates_redirect(client, site):
     assert response.status_code == 301
 
 
-
-
+@pytest.mark.skipif(
+    WAGTAIL_VERSION < (2, 10),
+    reason="Move signals require wagtail 2.10 or higher"
+)
 @pytest.mark.django_db
 def test_move_page_from_one_index_to_another_creates_redirect_for_child(
         client,

--- a/tests/test_pages.py
+++ b/tests/test_pages.py
@@ -147,3 +147,67 @@ def test_move_page_from_one_index_to_another_creates_redirect(client, site):
     response = client.get(test_page_url_pre_move)
     assert response.status_code == 301
 
+
+
+
+@pytest.mark.django_db
+def test_move_page_from_one_index_to_another_creates_redirect_for_child(
+        client,
+        site,
+    ):
+    test_index_page_1 = factories.AutomaticRedirectsTestIndexPageFactory(
+        parent=site.root_page,
+        title='Automatic redirects test index page 1',
+        slug='index-page-1',
+        subtitle='Test subtitle',
+        body='<p>Test body</p>',
+    )
+
+    response = client.get(test_index_page_1.get_url())
+    assert response.status_code == 200
+
+    test_index_page_2 = factories.AutomaticRedirectsTestIndexPageFactory(
+        parent=site.root_page,
+        title='Automatic redirects test index page 2',
+        slug='index-page-2',
+        subtitle='Test subtitle',
+        body='<p>Test body</p>',
+    )
+
+    response = client.get(test_index_page_2.get_url())
+    assert response.status_code == 200
+
+    test_page = factories.AutomaticRedirectsTestPageFactory(
+        parent=test_index_page_1,
+        title='Test Page',
+        slug='test-page'
+    )
+
+    response = client.get(test_page.get_url())
+    assert response.status_code == 200
+
+    test_page_child = factories.AutomaticRedirectsTestPageFactory(
+        parent=test_page,
+        title='Test Page Child',
+        slug='test-page-child'
+    )
+
+    test_page_child_url_pre_move = test_page_child.get_url()
+    response = client.get(test_page_child_url_pre_move)
+    assert response.status_code == 200
+
+
+    test_page.move(test_index_page_2, 'last-child')
+
+    test_page_child.refresh_from_db()
+    test_page_child_url_post_move = test_page_child.get_url()
+
+    assert test_index_page_1.get_descendants().count() == 0
+    assert test_index_page_2.get_descendants().count() == 2
+    assert test_index_page_1.get_url() not in test_page_child_url_post_move
+    assert test_index_page_2.get_url() in test_page_child_url_post_move
+
+    response = client.get(test_page_child_url_post_move)
+    assert response.status_code == 200
+    response = client.get(test_page_child_url_pre_move)
+    assert response.status_code == 301

--- a/wagtail_automatic_redirects/signal_handlers.py
+++ b/wagtail_automatic_redirects/signal_handlers.py
@@ -7,7 +7,7 @@ if WAGTAIL_VERSION >= (2, 0):
     if WAGTAIL_VERSION >= (2, 10):
         from wagtail.core.signals import post_page_move
     else:
-        pre_page_move = None
+        post_page_move = None
 else:
     from wagtail.wagtailcore.signals import page_published
     from wagtail.wagtailredirects.models import Redirect

--- a/wagtail_automatic_redirects/signal_handlers.py
+++ b/wagtail_automatic_redirects/signal_handlers.py
@@ -69,6 +69,8 @@ def create_redirect_object_after_page_move(sender, **kwargs):
         }
     )
 
+    create_redirect_objects_for_children(page_before_url, page_after)
+
 
 # Register receivers
 def register_signal_handlers():


### PR DESCRIPTION
Wagtail 2.10 has added the `pre_page_move` and `post_page_move` signals. 

These signals allow for the automatic creation of redirects when a page is moved. Previously, this was only possible for slug changes.

Two tests are added. One to check redirect creation for the moved page itself. The other test checks the redirect creation for a child page of the moved page. 

The redirect creation for the child pages re-uses the existing `create_redirect_objects_for_children` function. 

Closes #6, because the signals make the use of the hooks unnecessary.

Please let me know if any changes are necessary for a merge.