### PR TITLE
Add license classifier

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,7 @@ setup(
         "Programming Language :: Python :: 3",
         "Framework :: Django",
         "Framework :: Wagtail",
+        "License :: OSI Approved :: BSD License",
     ],
     setup_requires=["setuptools_scm", "pytest-runner"],
     python_requires=">=3.6",


### PR DESCRIPTION
Adding the license classifier allows tools like `pip-license` to determine the license of the package from PyPI.
This is helpful for other projects e.g. to establish license checks in CI.