### PR TITLE
Update Shiftleft config to only run when access token is present

### DIFF
--- a/.github/workflows/shiftleft.yml
+++ b/.github/workflows/shiftleft.yml
@@ -17,6 +17,7 @@ jobs:
       run: |
         curl https://cdn.shiftleft.io/download/sl > ${GITHUB_WORKSPACE}/sl && chmod a+rx ${GITHUB_WORKSPACE}/sl
     - name: Python
+      if: env.SHIFTLEFT_ACCESS_TOKEN != null
       run: ${GITHUB_WORKSPACE}/sl analyze --verbose --app wagtail-automatic-redirects --tag branch=${GITHUB_REF} --python $(pwd)
       env:
         SHIFTLEFT_ACCESS_TOKEN: ${{ secrets.SHIFTLEFT_ACCESS_TOKEN }}


### PR DESCRIPTION
This PR will make Shiftleft conditionally cancel if the access token is not available (e.g. when Dependabot runs, it does not have access to the SHIFTLEFT_ACCESS_TOKEN and causes a failure when this is not intended)

[_Created by Sourcegraph batch change `ntravis/add-condition-for-shiftleft`._](https://themotleyfool.sourcegraph.com/users/ntravis/batch-changes/add-condition-for-shiftleft)