### PR TITLE
Wagtai 3.0 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ jobs:
 install:
   - pip install -U setuptools
   - pip install -U pip
+  - pip install -U importlib-metadata
   - pip install .
   - pip install -U .[test]
 script:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# Unreleased
+Add support for Wagtail 3.0 and drop support for all Wagtail versions before 2.15
+
 # 1.1.5
 
 - Create a redirect when a page gets moved (https://github.com/themotleyfool/wagtail-automatic-redirects/pull/9).

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 from os import path
 
-install_requires = ["wagtail"]
+install_requires = ["wagtail>=2.15"]
 
 tests_require = ["pytest-django", "wagtail-factories", "pytest"]
 
@@ -31,10 +31,17 @@ setup(
         "Topic :: Software Development",
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
         "Framework :: Django",
+        "Framework :: Django :: 3.2",
+        "Framework :: Django :: 4.0",
         "Framework :: Wagtail",
+        "Framework :: Wagtail :: 2",
+        "Framework :: Wagtail :: 3",
         "License :: OSI Approved :: BSD License",
     ],
     setup_requires=["setuptools_scm", "pytest-runner"],
-    python_requires=">=3.6",
+    python_requires=">=3.7",
 )

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -1,8 +1,11 @@
 import pytest
-
+from wagtail import VERSION as WAGTAIL_VERSION
 
 @pytest.fixture
 def site():
-    from wagtail.core.models import Site
+    if WAGTAIL_VERSION >= (3, 0):
+        from wagtail.models import Site
+    else:
+        from wagtail.core.models import Site
     site = Site.objects.get(is_default_site=True)
     return site

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -2,6 +2,10 @@ import os
 from wagtail import VERSION as WAGTAIL_VERSION
 
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+ALLOWED_HOSTS = [
+    '127.0.0.1',
+    'localhost',
+]
 
 ADMINS = (
     ('test@example.com', 'TEST-R'),

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -1,4 +1,5 @@
 import os
+from wagtail import VERSION as WAGTAIL_VERSION
 
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
@@ -26,7 +27,7 @@ INSTALLED_APPS = [
     'wagtail.images',
     'wagtail.search',
     'wagtail.admin',
-    'wagtail.core',
+    'wagtail' if WAGTAIL_VERSION >= (3, 0) else "wagtail.core",
     'modelcluster',
     'taggit',
 

--- a/tests/testapp/migrations/0001_initial.py
+++ b/tests/testapp/migrations/0001_initial.py
@@ -2,7 +2,12 @@
 from __future__ import unicode_literals
 
 from django.db import migrations, models
-import wagtail.core.fields
+from wagtail import VERSION as WAGTAIL_VERSION
+if WAGTAIL_VERSION >= (3, 0):
+    import wagtail.fields as wagtail_fields
+else:
+    import wagtail.core.fields as wagtail_fields
+
 
 
 class Migration(migrations.Migration):
@@ -17,7 +22,7 @@ class Migration(migrations.Migration):
             fields=[
                 ('page_ptr', models.OneToOneField(on_delete=models.deletion.CASCADE, parent_link=True, auto_created=True, primary_key=True, serialize=False, to='wagtailcore.Page')),
                 ('subtitle', models.CharField(default=b'', max_length=255, blank=True)),
-                ('body', wagtail.core.fields.RichTextField(default=b'', blank=True)),
+                ('body', wagtail_fields.RichTextField(default=b'', blank=True)),
             ],
             options={
                 'abstract': False,
@@ -28,7 +33,7 @@ class Migration(migrations.Migration):
             name='AutomaticRedirectsTestPage',
             fields=[
                 ('page_ptr', models.OneToOneField(on_delete=models.deletion.CASCADE, parent_link=True, auto_created=True, primary_key=True, serialize=False, to='wagtailcore.Page')),
-                ('body', wagtail.core.fields.RichTextField(default=b'', blank=True)),
+                ('body', wagtail_fields.RichTextField(default=b'', blank=True)),
             ],
             options={
                 'abstract': False,

--- a/tests/testapp/models.py
+++ b/tests/testapp/models.py
@@ -1,8 +1,15 @@
 from django.db import models
+from wagtail import VERSION as WAGTAIL_VERSION
 
-from wagtail.admin.edit_handlers import FieldPanel
-from wagtail.core.fields import RichTextField
-from wagtail.core.models import Page
+if WAGTAIL_VERSION >= (3, 0):
+    from wagtail.admin.panels import FieldPanel
+    from wagtail.fields import RichTextField
+    from wagtail.models import Page
+else:
+    from wagtail.admin.edit_handlers import FieldPanel
+    from wagtail.core.fields import RichTextField
+    from wagtail.core.models import Page
+
 
 
 class AutomaticRedirectsTestIndexPage(Page):

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -1,7 +1,13 @@
 from django.conf.urls import include, url
+from wagtail import VERSION as WAGTAIL_VERSION
 
 from wagtail.admin import urls as wagtailadmin_urls
-from wagtail.core import urls as wagtail_urls
+
+if WAGTAIL_VERSION >= (3, 0):
+    from wagtail import urls as wagtail_urls
+else:
+    from wagtail.core import urls as wagtail_urls
+
 
 urlpatterns = [
     url(r'^admin/', include(wagtailadmin_urls)),

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import include, url
+from django.urls import include, path
 from wagtail import VERSION as WAGTAIL_VERSION
 
 from wagtail.admin import urls as wagtailadmin_urls
@@ -10,6 +10,6 @@ else:
 
 
 urlpatterns = [
-    url(r'^admin/', include(wagtailadmin_urls)),
-    url(r'', include(wagtail_urls)),
+    path("admin/", include(wagtailadmin_urls)),
+    path("", include(wagtail_urls)),
 ]

--- a/wagtail_automatic_redirects/signal_handlers.py
+++ b/wagtail_automatic_redirects/signal_handlers.py
@@ -1,17 +1,13 @@
 from wagtail import VERSION as WAGTAIL_VERSION
 
-if WAGTAIL_VERSION >= (2, 0):
+if WAGTAIL_VERSION >= (3, 0):
+    from wagtail.signals import page_published
+    from wagtail.contrib.redirects.models import Redirect
+    from wagtail.signals import post_page_move
+elif WAGTAIL_VERSION >= (2, 15):
     from wagtail.core.signals import page_published
     from wagtail.contrib.redirects.models import Redirect
-
-    if WAGTAIL_VERSION >= (2, 10):
-        from wagtail.core.signals import post_page_move
-    else:
-        post_page_move = None
-else:
-    from wagtail.wagtailcore.signals import page_published
-    from wagtail.wagtailredirects.models import Redirect
-
+    from wagtail.core.signals import post_page_move
 
 # Create redirect from old slug to new if slug changed in published page.
 # Redirect will be created for Page and all it's children.

--- a/wagtail_automatic_redirects/signal_handlers.py
+++ b/wagtail_automatic_redirects/signal_handlers.py
@@ -1,3 +1,4 @@
+import json
 from wagtail import VERSION as WAGTAIL_VERSION
 
 if WAGTAIL_VERSION >= (3, 0):
@@ -29,8 +30,12 @@ def create_redirect_object_if_slug_changed(sender, **kwargs):
     # JSON and value is stored as JSON in revision.
     page_revisions = instance.revisions.order_by('-created_at', '-id')
     for revision in page_revisions:
-        page_obj = revision.page.specific_class.from_json(
-            revision.content_json)
+        if WAGTAIL_VERSION >= (3, 0):
+            page_obj = revision.page.specific_class.from_json(
+                json.dumps(revision.content))
+        else:
+            page_obj = revision.page.specific_class.from_json(
+                revision.content_json)
 
         # The first revision's page object that has has_published_changes
         # value False is the last published Page.

--- a/wagtail_automatic_redirects/signal_handlers.py
+++ b/wagtail_automatic_redirects/signal_handlers.py
@@ -71,9 +71,7 @@ def create_redirect_object_after_page_move(sender, **kwargs):
 # Register receivers
 def register_signal_handlers():
     page_published.connect(create_redirect_object_if_slug_changed)
-
-    if post_page_move is not None:
-        post_page_move.connect(create_redirect_object_after_page_move)
+    post_page_move.connect(create_redirect_object_after_page_move)
 
 
 def create_redirect_objects_for_children(parent_old_slug, parent):


### PR DESCRIPTION
Fix https://github.com/themotleyfool/wagtail-automatic-redirects/issues/18: Make this package support Wagtail 3.0. 

CI: https://github.com/BrianXu20/wagtail-automatic-redirects/pull/1

- Install importlib-metadata in the CI to prevent this [error](https://app.travis-ci.com/github/themotleyfool/wagtail-automatic-redirects/jobs/574188791)
- Add ALLOWED_HOSTS to prevent DisallowedHost [error](https://app.travis-ci.com/github/themotleyfool/wagtail-automatic-redirects/jobs/574189298)
- Use `path` instead of `url` in the router, this is to support Django4.
- Add support for Wagtail 3.0 and drop support for all Wagtail versions before 2.15
- Update setup.py with more detailed package information